### PR TITLE
ignore splitting tags with escaped commas in series

### DIFF
--- a/influxgraph/utils.py
+++ b/influxgraph/utils.py
@@ -275,7 +275,7 @@ def parse_series(series, fields, graphite_templates, separator=b'.'):
         # pre-generate a correctly ordered split path for that metric
         # to be inserted into index
         if graphite_templates or ',' in serie:
-            serie_with_tags = serie.split(',')
+            serie_with_tags = re.split(r'(?<!\\),', serie)
             if graphite_templates:
                 for split_path in get_series_with_tags(
                         serie_with_tags, fields, graphite_templates,


### PR DESCRIPTION
Influxgraph crashes when parses series with escaped comma in tags.

Example:
Telegraf's mysql input produes a measurement mysql_variables with tag tls_version, which can contain escaped commas:
```mysql_variables,tls_version=TLSv1.1\,TLSv1.2,source=telegraf,protocol_version=10 thread_statistics=0,sync_relay_log_info=10000,thread_pool_size=2,tls_version="TLSv1.1,TLSv1.2",threa    d_concurrency=10,thread_pool_oversubscribe=3,... 1515760350000000000```

This results with tag_values like: 
```[u'tls_version', u'TLSv1.1\\'], [u'TLSv1.2']```
and:
```Traceback (most recent call last):
(...)
  File "/opt/graphite-api/site-packages/influxgraph/templates.py", line 274, in _make_path_from_template
    for (tag_key, tag_val) in tags_values:
ValueError: expected length 2, got 1
``` 

The proposed change uses negative lookbehind assertion to avoid that.
I haven't noticed performance degradation using re.split().